### PR TITLE
Remove unnecessary alias for the psutil module

### DIFF
--- a/SwagLyricsBot/dev_commands.py
+++ b/SwagLyricsBot/dev_commands.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from random import getrandbits
 
 import discord
-import psutil as psutil
+import psutil
 from discord.ext import commands
 
 process = psutil.Process()


### PR DESCRIPTION
The `psutil` module was imported with the same namespace, i.e `import psutil as psutil` which is equivalent to `import psutil` in theory