### PR TITLE
Added AllowedMentions so the bot won't mention @everyone

### DIFF
--- a/SwagLyricsBot/swaglyrics_bot.py
+++ b/SwagLyricsBot/swaglyrics_bot.py
@@ -10,7 +10,8 @@ from SwagLyricsBot.general_commands import GeneralCommands
 from SwagLyricsBot.links_commands import LinksCommands
 from SwagLyricsBot.topGG import TopGG
 
-bot = commands.Bot(command_prefix=when_mentioned_or("$"), help_command=None)
+bot = commands.Bot(command_prefix=when_mentioned_or("$"), help_command=None,
+                   allowed_mentions=discord.AllowedMentions(roles=False, users=False, everyone=False)
 
 
 def find_mutual_guild(user_id):

--- a/SwagLyricsBot/swaglyrics_bot.py
+++ b/SwagLyricsBot/swaglyrics_bot.py
@@ -11,7 +11,7 @@ from SwagLyricsBot.links_commands import LinksCommands
 from SwagLyricsBot.topGG import TopGG
 
 bot = commands.Bot(command_prefix=when_mentioned_or("$"), help_command=None,
-                   allowed_mentions=discord.AllowedMentions(roles=False, users=False, everyone=False)
+                   allowed_mentions=discord.AllowedMentions(roles=False, users=False, everyone=False))
 
 
 def find_mutual_guild(user_id):


### PR DESCRIPTION
Allowed Mentions has been added so the bot cannot be tricked into using @everyone, @here or any other mention.