### PR TITLE
Use python dotenv instead of env file

### DIFF
--- a/.github/workflows/python-linting.yml
+++ b/.github/workflows/python-linting.yml
@@ -23,12 +23,13 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
+        pip install flake8 pytest black
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
+    - name: Lint with flake8 & black
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 SwagLyricsBot --count --max-line-length=120 --max-complexity=10 --show-source --statistics
+        black -l 120 --check --diff .
 #     - name: Test with pytest
 #       run: |
 #         pytest

--- a/SwagLyricsBot/__init__.py
+++ b/SwagLyricsBot/__init__.py
@@ -19,7 +19,7 @@ class SpotifyClosed(LyricsError):
         message="You are not listening to anything or Spotify is not connected to Discord! \n "
         "Make sure you have enabled status in Settings -> Connections -> Spotify -> Display "
         "Spotify as your status or use `$sl [song] ,, [artist]`\nExample: `$sl "
-        'Bad Guy ,, Billie Eilish`.',
+        "Bad Guy ,, Billie Eilish`.",
     ):
         super().__init__(message)
 

--- a/SwagLyricsBot/__init__.py
+++ b/SwagLyricsBot/__init__.py
@@ -19,7 +19,7 @@ class SpotifyClosed(LyricsError):
         message="You are not listening to anything or Spotify is not connected to Discord! \n "
         "Make sure you have enabled status in Settings -> Connections -> Spotify -> Display "
         "Spotify as your status or use `$sl [song] ,, [artist]`\nExample: `$sl "
-        '"Bad Guy" "Billie Eilish"`.',
+        'Bad Guy ,, Billie Eilish`.',
     ):
         super().__init__(message)
 

--- a/SwagLyricsBot/general_commands.py
+++ b/SwagLyricsBot/general_commands.py
@@ -28,7 +28,7 @@ class GeneralCommands(commands.Cog, name="General"):
             name="`$sl` or `$swaglyrics`",
             value="Automatically get lyrics for music you are currently "
             "listening to on Spotify. Optionally, to get lyrics for a specific song, use "
-            '`$sl [song] ,, [artist]`. \nEg. `$sl In The End ,, Linkin Park`',
+            "`$sl [song] ,, [artist]`. \nEg. `$sl In The End ,, Linkin Park`",
             inline=False,
         )
         embed.add_field(name="`$invite` or `$topgg`", value="Link to the bot's top.gg page", inline=False)

--- a/SwagLyricsBot/swaglyrics_bot.py
+++ b/SwagLyricsBot/swaglyrics_bot.py
@@ -1,14 +1,18 @@
+import os
+
 import aiohttp
-import env_file
 from discord import Activity, ActivityType, AllowedMentions
 from discord.ext import commands
 from discord.ext.commands import when_mentioned_or
+from dotenv import load_dotenv
 
 from SwagLyricsBot import logs
 from SwagLyricsBot.dev_commands import DevCommands
 from SwagLyricsBot.general_commands import GeneralCommands
 from SwagLyricsBot.links_commands import LinksCommands
 from SwagLyricsBot.topGG import TopGG
+
+load_dotenv()  # load env vars
 
 bot = commands.Bot(command_prefix=when_mentioned_or("$"), help_command=None, allowed_mentions=AllowedMentions.none())
 
@@ -34,14 +38,11 @@ async def run():
     Bot setup
     """
     async with aiohttp.ClientSession() as session:
-        token = env_file.get()
         bot.add_cog(DevCommands(bot))
         bot.add_cog(GeneralCommands(bot, session))
         bot.add_cog(LinksCommands(bot))
-        if "DBL_TOKEN" in token:
-            bot.add_cog(TopGG(bot, token["DBL_TOKEN"]))
-        if "WEBHOOK_URL" in token:
-            logs.webhook_url = token["WEBHOOK_URL"]
-        if "WEBHOOK_ERROR_SUPERVISOR_ID" in token:
-            logs.error_supervisor = token["WEBHOOK_ERROR_SUPERVISOR_ID"]
-        await bot.start(token["BOT_TOKEN"])
+        if os.getenv("DBL_TOKEN"):
+            bot.add_cog(TopGG(bot, os.getenv("DBL_TOKEN")))
+        logs.webhook_url = os.getenv("WEBHOOK_URL")  # None if not set
+        logs.error_supervisor = os.getenv("WEBHOOK_ERROR_SUPERVISOR_ID")
+        await bot.start(os.environ["BOT_TOKEN"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiohttp[speedups]==3.7.2
 beautifulsoup4==4.9.1
 dblpy==0.4.0
 discord.py==1.5.1
-env-file==2020.7.1
+python-dotenv==0.15.0
 psutil==5.7.3
 swaglyrics==1.2.0
 aiocfscrape==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -13,20 +13,10 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/flabbet/SwagLyrics-discord-bot",
-    packages=['SwagLyricsBot'],
-    install_requires=[
-        'swaglyrics',
-        'discord',
-        'env_file'
-    ],
-    extras_require={
-        'dev': [
-            'pytest',
-            'codecov',
-            'pytest-cov'
-        ]
-    },
-    keywords='discord bot swaglyrics lyrics',
+    packages=["SwagLyricsBot"],
+    install_requires=["swaglyrics", "discord", "env_file"],
+    extras_require={"dev": ["pytest", "codecov", "pytest-cov"]},
+    keywords="discord bot swaglyrics lyrics",
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -131,7 +131,6 @@ Arguing with my dad, and he said, "It ain't Christ-like"
         with self.assertRaises(LyricsNotFound):
             asyncio.create_task(GeneralCommands.get_lyrics("(*&d78a kj"))
 
-
     def test_that_pack_into_messages_returns_empty_message(self):
         chunks = []
         messages = GeneralCommands.pack_into_messages(chunks)
@@ -144,10 +143,16 @@ Arguing with my dad, and he said, "It ain't Christ-like"
         self.assertEqual(len(messages), 1)
 
     def test_that_pack_into_messages_packs_into_two(self):
-        chunks = [self.testing_lyrics, self.testing_lyrics, self.testing_lyrics, self.testing_lyrics_2, self.testing_lyrics_2]
+        chunks = [
+            self.testing_lyrics,
+            self.testing_lyrics,
+            self.testing_lyrics,
+            self.testing_lyrics_2,
+            self.testing_lyrics_2,
+        ]
         messages = GeneralCommands.pack_into_messages(chunks)
         self.assertEqual(len(messages), 2)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Allows for both .env file and also just setting up the environment variable. Simplifies the code a bit too.

Updated the message in the init with the new delimiter.

Blackening. 